### PR TITLE
Inputted Start Date changes logs

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplanting.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplanting.html
@@ -2,12 +2,20 @@
     <div id="transplanting">
         <h1>Transplanting Report</h1>
         <label for="start">Start Date:</label>
-        <input type="date" id="start" name="start" v-bind:max=endDate v-model="startDate">
+        <input type="date" id="start" name="start" v-bind:max="endDate" v-model="startDate">
 
         <br>
 
         <label for="end">End Date:</label>
-        <input type="date" id="end" name="end" v-bind:min=startDate  v-model="endDate">
+        <input type="date" id="end" name="end" v-bind:min="startDate"  v-model="endDate">
+
+        <br>
+
+        <div class="add-item-form">
+            <button class="btn btn-primary" v-on:click="saveLogs">
+                Generate Report
+            </button>
+        </div>
 
         <table style="width:100%" border=1>
             <tr>
@@ -39,11 +47,37 @@
                 message: 'Hi guys!',
                 startDate: '',
                 endDate: '',
+                logs: [],
             },
             created(){
             },
             methods: {
-               
+               saveLogs: function(){
+                   let link = '/log.json?bundle=farm_transplanting';
+                   if(this.startDate != ''){
+                       let unixT = this.YMDToTimestamp(this.startDate);
+                       link = link + '&timestamp[ge]=' + unixT;
+                   }
+                   axios.get(link).then(response => {
+                       this.logs = response.data.list.map(h => {
+                           return{
+                               date:this.timestampToYMD(h.timestamp),
+                           };
+                       });
+                   })
+               },
+               timestampToYMD: function(timestamp){
+                   let d = new Date(timestamp*1000);
+                   const month = d.getMonth() < 9 ? '0' + (d.getMonth() + 1): 
+                        d.getMonth() + 1;
+                    const day = d.getDate() < 10 ? '0' + d.getDate() :
+				        d.getDate();
+			        return d.getFullYear() + "-" + month + "-" + day;
+               },
+               YMDToTimestamp: function(ymd){
+                    let d = new Date(ymd);
+                    return Math.round(d.getTime()/1000 + new Date().getTimezoneOffset()*60);
+               },
             },
             computed:{
             },


### PR DESCRIPTION
Now when the generate button is hit the instance that appear in Vue.js from the data are only after the start date that was inputted

In order for this to be created, a Generate Report button, a logs variable in Vue.js, and a saveLogs method was created. When the Generate report button is clicked the saveLogs method is started. In the saved logs method a variable called link is created. This variable is set to the standard link for all transplanting log. Then if startDate is not empty then the link variable is added to in order to create a link that will get all transplanting logs created after that start date. Then that link is used in the axios call. In order to do this, the methods timestampToYMD and YMDToTimestamp were created. This methods change YMD time to timestamp time and vice versa.

__Pull Request Description__

<Add description>

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
