### PR TITLE
Inputted end date changes logs that appear in Vue

### DIFF
--- a/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplanting.html
+++ b/farmdata2_modules/fd2_tabs/fd2_barn_kit/transplanting.html
@@ -58,6 +58,10 @@
                        let unixT = this.YMDToTimestamp(this.startDate);
                        link = link + '&timestamp[ge]=' + unixT;
                    }
+                    if(this.endDate != ''){
+                       let unixT = this.YMDToTimestamp(this.endDate);
+                       link = link + '&timestamp[le]=' + unixT;
+                   }
                    axios.get(link).then(response => {
                        this.logs = response.data.list.map(h => {
                            return{


### PR DESCRIPTION
the variable endDate now effects what logs show up in the Vue.js logs.

In the saveLogs method, if the endDate variable is not empty. The link varibale is added to, so that the link will only call transplanting logs that happened before that date. 

__Pull Request Description__

<Add description>

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
